### PR TITLE
Ensure requests to favicon.ico don't end up causing failures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ const handler = async (req, res) => {
         'MMMM Do @ HH:mm',
       ),
       compareableDate: format(new Date(list[0].created * 1000), 'MM/DD'),
-    }));
+    }))
+    .catch(console.error);
   const isBirthday =
     compareAsc(
       format(new Date(), 'MM/DD'),
@@ -32,6 +33,7 @@ const handler = async (req, res) => {
   );
 };
 
+app.get('/favicon.ico', (req, res) => res.status(404));
 app.get('/:username', handler);
 
 app.listen(3000, () => console.log('Listening on port 3000!'));


### PR DESCRIPTION
By default browsers send out a request to ```favicon.ico```, so let's catch that to not cause another request to drupal.org asking for a user with name "favicon.ico"